### PR TITLE
:sparkles: add tool for hisat2 alignment

### DIFF
--- a/tools/hisat2_align.cwl
+++ b/tools/hisat2_align.cwl
@@ -49,8 +49,8 @@ arguments:
 
 inputs:
   reference: {type: File, doc: "tarball of reference files"}
-  fastq1: {type: File, doc: "gzipped forward fq file"}
-  fastq2: {type: File?, doc: "gzipped reverse fq file"}
+  fastq1: {type: File, doc: "gzipped read 1 fq file"}
+  fastq2: {type: File?, doc: "gzipped read 2 fq file"}
   output_basename: {type: string, doc: "Output file basename"}
   input_id: {type: string, doc: "Sample name"}
   strict: {type: boolean?, doc: "Flag to use a stricter alignment to make input bam for RSEM"}


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 

Adds hisat2 alignment tool. The tool can align data to the genome or the transcriptome and input data can be single or paired end. When aligning to the transcriptome, an additional parameter "strict" is used which has stricter mapping settings to force reads to only align once. When the strict parameter is used, the output bam is unsorted which is needed for use in RSEM.

Partially Fixes https://app.zenhub.com/workspaces/d3b-bfx-5cdd720eed0dce4209e0b8a5/issues/d3b-center/bixu-tracker/987

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] [Cavatica test aligning single ended data to the genome](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/502f82f5-4186-4de7-85ae-0d15c284e05c/)
- [X] [Cavatica test aligning single ended data to the transcriptome](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/fbed1b69-191d-4d81-ac67-1441608caad4/)

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
