### PR TITLE
Seurat merge cwl tool

### DIFF
--- a/tools/seurat_merge.cwl
+++ b/tools/seurat_merge.cwl
@@ -21,7 +21,7 @@ arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      seurat_merge.R --matrix_files ${var name_string = ""; for (var i=0; i<inputs.matrix_rds_files.length-1; i++){name_string += inputs.matrix_rds_files[i].path+","} name_string += inputs.matrix_rds_files[inputs.matrix_rds_files.length-1].path; return name_string} --output_name $(inputs.output_name)
+      seurat_merge.R --matrix_files $(inputs.matrix_rds_files.map(function(i){return i.path}).join()) --output_name $(inputs.output_name)
 
 inputs:
   matrix_rds_files:


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This is a tool that wraps the R script that merges 10X single cell count matrices using Seurat. It uses the same Docker image that is used for the SoupX decontamination step; this is a large image and isn't wholly necessary, but since another step in the same workflow uses it perhaps there is no added cost? 

Fixes #https://github.com/d3b-center/bixu-tracker/issues/986

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] On Cavatica: https://cavatica.sbgenomics.com/u/nathanj/test-project/tasks/74c69ec6-4cae-4a0c-93a3-4bae22fe05c5/#

I still use Rabix to push to Cavatica, so I had to change the CWL version to 1.0 to get it up there, but it worked with 1.2 on my EC2 instance. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
