### PR TITLE
🔨  Modify Outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,20 @@
 
 This repo contains tools and workflows for analyzing single cell RNA (scRNA) data from 10X and SmartSeq2
 
-The repo is currently in alpha phase.
-
-## [10X Cell Ranger 6.2.1 Alignment Workflow](docs/10X_cell_ranger_alignment.md)
-Aligns and quantifies 10X single cell data using Cell Ranger
-## [10X STAR Solo 2.7.10b Alignment Workflow](docs/10X_STAR_Solo_alignment.md)
+## Production Workflows
+These workflows are considered acceptable for Single Cell Anaylsis
+### [10X STAR Solo 2.7.10b Alignment Workflow](docs/10X_STAR_Solo_alignment.md)
 Aligns and quantifies 10X single cell data using STAR Solo
-## [10X Refinement Workflow](docs/10X_refinement.md)
+
+## Alpha Phase Workflows
+These workflows are currently in alpha phase
+
+### [10X Cell Ranger 6.2.1 Alignment Workflow](docs/10X_cell_ranger_alignment.md)
+Aligns and quantifies 10X single cell data using Cell Ranger
+### [10X Refinement Workflow](docs/10X_refinement.md)
 Filters and cleans up results from both Cell Ranger and STAR Solo outputs
 
-## [Smart Seq 2 Workflow](docs/SMART_SEQ2.md)
+### [Smart Seq 2 Workflow](docs/SMART_SEQ2.md)
 The workflow uses [HISAT2](http://daehwankimlab.github.io/hisat2/) for alignment, [RNAseQC](https://github.com/getzlab/rnaseqc) to collect sequencing metrics, and [RSEM](https://deweylab.github.io/RSEM/) to calculate gene expression.
 The outputs of the workflow are a matrix of cells gene counts in a loom file, a tarball containing a matrix of the gene counts in Matrix Market format, and a tsv with collected sequencing metrics from all cells analyzed.
 Basic functionality includes removal of abnormal cells, dimensionality reduction, identification of differentially expressed features, and clustering.

--- a/docs/10X_SEURAT_HBC_SCRNA_QC.md
+++ b/docs/10X_SEURAT_HBC_SCRNA_QC.md
@@ -1,16 +1,18 @@
 # Seurat HBC scRNA QC Outputs
-Based on [this tutorial](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md) and some Kids First-specific tweaks, the [QC step/script](../scripts/seurat_hbc_scrna_qc.R) does the following:
+Based on [this tutorial](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md) and some Kids First-specific tweaks, the [QC step/script](../scripts/seurat_hbc_scrna_qc.R) does the following, with output files **_emphasized_**:
 1. Calculate novelty score: log<sub>10</sub>(nFeaureRNA)/log<sub>10</sub>(nCount_RNA). This is described well [here](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md#complexity)
 1. Calculate mitochondrial ratio. This is done by searching gene symbols starting with `MT-` 
-1. Output tsv file with QC metrics pre-filtering. Example excerpt:
+1. **_qc_barcode_metrics_**:  output_basename + ".barcode_qc.metrics.tsv". Output tsv file with QC metrics pre-filtering. Example excerpt:
    ```tsv
-   cell_ids	orig.ident	nCount_RNA	nFeature_RNA	log10GenesPerUMI	mitoRatio	sample
-   AAACCCAAGCAGATAT	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	8952.9999803	4235	0.917733361994601	0.000223388808712248	7316-2146
-   AAACCCAAGGATCACG	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	1633.9999964	1122	0.949191911584887	0.000611995105387504	7316-2146
-   AAACCCAAGGGTTTCT	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	225.9999976	236	1.00798755408155	0	7316-2146
-   AAACCCACAATCACGT	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	1289.0000016	976	0.961159718063171	0	7316-2146
-   AAACCCACACTACCGG	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	1994.000028	1349	0.948567470874349	0	7316-2146
+   cell_ids	seq_source	nUMI	nGene	log10GenesPerUMI	mitoRatio	sample
+   AAACCCAAGGAGAGTA	delem_test_refactor.EM.raw.h5	9118.0000543	2956	0.876462736098413	0.116979632994956	pbmc
+   AAACGCTTCAGCCCAG	delem_test_refactor.EM.raw.h5	6014.999944	2103	0.879235803237773	0.0904405660955398	pbmc
+   AAAGAACAGACGACTG	delem_test_refactor.EM.raw.h5	4586.999945	1778	0.887588761938559	0.0671312412671067	pbmc
+   AAAGAACCAATGGCAG	delem_test_refactor.EM.raw.h5	3013.0000477	1404	0.90467602389422	0.0713574499157815	pbmc
+   AAAGAACGTCTGCAAT	delem_test_refactor.EM.raw.h5	7107.0004425	2119	0.863551873376804	0.0697698282154005	pbmc
+   AAAGGATAGTAGACAT	delem_test_refactor.EM.raw.h5	9537.9999555	2374	0.848226390313623	0.0849234644347971	pbmc
    ```
+   Note, default Suerat column names were renamed for clarity: `orig.ident -> seq_source, nCount_RNA -> nUMI, nFeature_RNA -> nGene`
 
 1. Apply cell-level filters. These are adjustable, and are considered a reasonable start without prior experimental knowledge. Defaults are:
    - `min_umi`: 500
@@ -18,14 +20,19 @@ Based on [this tutorial](https://github.com/hbctraining/scRNA-seq_online/blob/sc
    - `min_complexity`: 0.8
    - `max_mito_ratio`: 0.2
 1. Drop genes with `0` counts and those present in less than `min_gene_prevalence` (default 10)
-1. _Save QC-filtered counts matrix in h5 format_
-1. Repeat novelty score and mito ratio calculations as well as generate post-filter QC plots.
+1. **_qc_filtered_ct_matrix_**: output_basename + ".qc_filtered.counts_matrix.h5". Save QC-filtered counts matrix in h5 format
 1. Normalize read counts using `NormalizeData` and `ScaleCounts`
 1. Find top 2000 variable features (transcripts) and create a dot plot labeling the top 15
-1. Create pre-filter and post-filter QC plots
+1. **_qc_variable_features_plot_**: output_basename + ".variable_features.pdf". PDF with a dot plot of variable genes with top 20 labeled
+1. **_qc_plots_**: output_basename + ".QC_plots.pdf. PDF with pre-filter and post-filter QC plots
    - Kernel density plot of Number of transcripts (`nCount_RNA`) per cell
    - Kernel density plot of Number of genes (`nFeaureRNA`) per cell
    - Kernel density plot of  cell complexity using novelty score
    - Kernel density plot of mitochondrial counts ratio
    - Dot plot filtering effects. The intercept lines represents cell data points that will be cut out for `nUMIs` (set by `min_umi` param) and `nGenes` (set by `min_genes`) param
-1. Generate pre and post-filter box plot stats and cell count stats
+1. **_qc_boxplot_stats_**: output_basename + ".boxplot_summary_metrics.tsv". TSV file with pre and post-filter box plot stats of the following QC metrics:
+   - Number of UMIs
+   - Number of Genes
+   - Novelty Score
+   - Mitochondrial Ratio
+1. **_qc_cell_counts_**: output_basename + ".cell_counts.tsv". TSV file with number of starting cells, number of cells affected by each of the QC cutoffs, and final cell count

--- a/docs/10X_SEURAT_HBC_SCRNA_QC.md
+++ b/docs/10X_SEURAT_HBC_SCRNA_QC.md
@@ -2,17 +2,26 @@
 Based on [this tutorial](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md) and some Kids First-specific tweaks, the [QC step/script](../scripts/seurat_hbc_scrna_qc.R) does the following:
 1. Calculate novelty score: log<sub>10</sub>(nFeaureRNA)/log<sub>10</sub>(nCount_RNA). This is described well [here](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md#complexity)
 1. Calculate mitochondrial ratio. This is done by searching gene symbols starting with `MT-` 
-1. _Save Seurat object with counts and metrics_
+1. Output tsv file with QC metrics pre-filtering. Example excerpt:
+   ```tsv
+   cell_ids	orig.ident	nCount_RNA	nFeature_RNA	log10GenesPerUMI	mitoRatio	sample
+   AAACCCAAGCAGATAT	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	8952.9999803	4235	0.917733361994601	0.000223388808712248	7316-2146
+   AAACCCAAGGATCACG	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	1633.9999964	1122	0.949191911584887	0.000611995105387504	7316-2146
+   AAACCCAAGGGTTTCT	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	225.9999976	236	1.00798755408155	0	7316-2146
+   AAACCCACAATCACGT	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	1289.0000016	976	0.961159718063171	0	7316-2146
+   AAACCCACACTACCGG	7316-2146_SOLO_NEW_QC_OUT.EM.raw.h5	1994.000028	1349	0.948567470874349	0	7316-2146
+   ```
+
 1. Apply cell-level filters. These are adjustable, and are considered a reasonable start without prior experimental knowledge. Defaults are:
    - `min_umi`: 500
    - `min_genes`: 250
    - `min_complexity`: 0.8
    - `max_mito_ratio`: 0.2
 1. Drop genes with `0` counts and those present in less than `min_gene_prevalence` (default 10)
+1. _Save QC-filtered counts matrix in h5 format_
 1. Repeat novelty score and mito ratio calculations as well as generate post-filter QC plots.
 1. Normalize read counts using `NormalizeData` and `ScaleCounts`
 1. Find top 2000 variable features (transcripts) and create a dot plot labeling the top 15
-1. _Save post-filter Seurat object with counts and metrics_
 1. Create pre-filter and post-filter QC plots
    - Kernel density plot of Number of transcripts (`nCount_RNA`) per cell
    - Kernel density plot of Number of genes (`nFeaureRNA`) per cell

--- a/docs/10X_STAR_Solo_alignment.md
+++ b/docs/10X_STAR_Solo_alignment.md
@@ -95,7 +95,8 @@ Output QC is based on [this tutorial](https://github.com/hbctraining/scRNA-seq_o
  - `qc_plots`: Pre and post filtering metrics PDF plots
  - `qc_boxplot_stats`: Pre and post filtering boxplot stats TSV
  - `qc_cell_counts`: Pre and post filtering cell counts TSV
- - `variable_features_plot`: PDF with a dot plot of variable genes with top 15 labeled
+ - `qc_filtered_ct_matrix`: h5 formatted counts matrix after applying minimum QC filtering
+ - `qc_variable_features_plot`: PDF with a dot plot of variable genes with top 15 labeled
 ## Appendix: Seurat HBC QC Output
 QC Outputs are based primarily on the training materials provided by the [Harvard Chan Bioinformatics Core](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md).
 An overview of how the QC was performed and overview of the outputs are provided [here](./10X_SEURAT_HBC_SCRNA_QC.md)

--- a/docs/10X_STAR_Solo_alignment.md
+++ b/docs/10X_STAR_Solo_alignment.md
@@ -91,11 +91,10 @@ Output QC is based on [this tutorial](https://github.com/hbctraining/scRNA-seq_o
  - `star_solo_log_final_out`: STAR align summary stats
  - `star_solo_junctions`: STAR splice junction result file
  - `star_solo_cr_mimic_counts`: Tar ball of Cell Ranger-style counts dir from STAR Solo
+ - `qc_barcode_metrics`: Table with barcodes and calculated QC metrics
  - `qc_plots`: Pre and post filtering metrics PDF plots
  - `qc_boxplot_stats`: Pre and post filtering boxplot stats TSV
- - `cell_counts`: Pre and post filtering cell counts TSV
- - `seurat_prefilter_data`: Seurat Rdata object with prefilter counts and metrics
- - `seurat_filtered_data`: Seurat Rdata object with basic filter counts and metrics
+ - `qc_cell_counts`: Pre and post filtering cell counts TSV
  - `variable_features_plot`: PDF with a dot plot of variable genes with top 15 labeled
 ## Appendix: Seurat HBC QC Output
 QC Outputs are based primarily on the training materials provided by the [Harvard Chan Bioinformatics Core](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md).

--- a/scripts/seurat_hbc_scrna_qc.R
+++ b/scripts/seurat_hbc_scrna_qc.R
@@ -176,7 +176,7 @@ message("Collating metadata")
 metadata_prefiltered <- seurat_counts@meta.data
 metadata_prefiltered$sample <- opts$sample_id
 message("Printing prefiltered QC Metrics")
-write.table(rownames_to_column(metadata_prefiltered, var="cell_ids"), paste0(opts$output_basename, ".barcode_qc.metrics.tsv"), quote=FALSE, row.names=FALSE)
+write.table(rownames_to_column(metadata_prefiltered, var="cell_ids"), paste0(opts$output_basename, ".barcode_qc.metrics.tsv"), quote=FALSE, row.names=FALSE, sep = "\t")
 seurat_counts@meta.data <- metadata_prefiltered
 
 message("Applying cell-level filters")
@@ -192,7 +192,7 @@ keep_genes <- Matrix::rowSums(nonzero) >= opts$min_gene_prevalence
 filtered_counts <- counts[keep_genes, ]
 filtered_seurat <- CreateSeuratObject(filtered_counts, meta.data = filtered_seurat@meta.data)
 message("Output QC filtered count matrix")
-filtered_ct_matrix_fname = paste0(output_basename, ".qc_filtered.counts_matrix.h5")
+filtered_ct_matrix_fname = paste0(opts$output_basename, ".qc_filtered.counts_matrix.h5")
 DropletUtils::write10xCounts(path = filtered_ct_matrix_fname, x = filtered_seurat@assays$RNA@data, type="HDF5")
 message("Repeating metrics and plots for filtered data")
 filtered_seurat <- calculate_metrics(filtered_seurat)
@@ -211,7 +211,7 @@ filtered_seurat <- FindVariableFeatures(filtered_seurat,
 filtered_seurat <- ScaleData(filtered_seurat)
 # Identify the 15 most highly variable genes
 ranked_variable_genes <- VariableFeatures(filtered_seurat)
-top_genes <- ranked_variable_genes[1:15]
+top_genes <- ranked_variable_genes[1:20]
 
 # Plot the average expression and variance of these genes
 # With labels to indicate which genes are in the top 15

--- a/tools/seurat_hbc_scrna_qc.cwl
+++ b/tools/seurat_hbc_scrna_qc.cwl
@@ -6,7 +6,7 @@ doc: "Run custom QC on 10X output"
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: "pgc-images.sbgenomics.com/brownm28/hbc_scrna_qc:v1.0.0-scrnaseq"
+    dockerPull: "pgc-images.sbgenomics.com/d3b-bixu/hbc_scrna_qc:scrnaseq"
   - class: InlineJavascriptRequirement
   - class: InitialWorkDirRequirement
     listing:
@@ -22,7 +22,7 @@ baseCommand: [Rscript, seurat_hbc_scrna_qc.R]
 inputs:
   bc_matrix_dir: { type: 'Directory?', loadListing: deep_listing, doc: "Path to 10X counts, like 'outs/raw_feature_bc_matrix'. Leave blank if using H5 inputs",
     inputBinding: { position: 1, prefix: "--data_dir"} }
-  h5_matrix_inputs: { type: 'File?', doc: "Path to h5 file with 10X count results. Leave bpanlif using counts directory",
+  h5_matrix_inputs: { type: 'File?', doc: "Path to h5 file with 10X count results. Leave blank if using counts directory",
     inputBinding: { position: 1, prefix: "--h5_counts" } }
   sample_id: { type: string, inputBinding: { position: 1, prefix: "--sample_id"} }
   output_basename: { type: string, inputBinding: { position: 1, prefix: "--output_basename"} }

--- a/tools/seurat_hbc_scrna_qc.cwl
+++ b/tools/seurat_hbc_scrna_qc.cwl
@@ -15,7 +15,7 @@ requirements:
           $include: ../scripts/seurat_hbc_scrna_qc.R
   - class: ResourceRequirement
     coresMin: 8
-    ramMin: 16000
+    ramMin: $(inputs.memory * 1000)
 
 baseCommand: [Rscript, seurat_hbc_scrna_qc.R]
 
@@ -36,6 +36,7 @@ inputs:
     inputBinding: { position: 1, prefix: "--max_mito_ratio"} }
   min_gene_prevalence: { type: 'int?', doc: "Minimum number of cells a gene must be expressed in to keep after filtering", default: 10,
     inputBinding: { position: 1, prefix: "--min_gene_prevalence" } }
+  memory: { type: 'int?', doc: "Memory in GB that ought to be available to the script", default: 16 }
 
 outputs:
   qc_barcode_metrics: { type: File, outputBinding: { glob: "*.barcode_qc.metrics.tsv"}, doc: "Table with barcodes and calculated QC metrics" }

--- a/tools/seurat_hbc_scrna_qc.cwl
+++ b/tools/seurat_hbc_scrna_qc.cwl
@@ -6,7 +6,7 @@ doc: "Run custom QC on 10X output"
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: "pgc-images.sbgenomics.com/d3b-bixu/hbc_scrna_qc:scrnaseq"
+    dockerPull: "pgc-images.sbgenomics.com/brownm28/hbc_scrna_qc:v1.0.0-scrnaseq"
   - class: InlineJavascriptRequirement
   - class: InitialWorkDirRequirement
     listing:
@@ -38,9 +38,9 @@ inputs:
     inputBinding: { position: 1, prefix: "--min_gene_prevalence" } }
 
 outputs:
+  qc_barcode_metrics: { type: File, outputBinding: { glob: "*.barcode_qc.metrics.tsv"}, doc: "Table with barcodes and calculated QC metrics" }
   qc_plots: { type: File, outputBinding: { glob: "*.QC_plots.pdf"}, doc: "Pre and post filtering metrics pdf plots"}
   qc_boxplot_stats: { type: File, outputBinding: { glob: "*_summary_metrics.tsv"}, doc: "Pre and post filtering boxplot stats tsv" }
-  cell_counts: { type: File, outputBinding: { glob: "*.cell_counts.tsv"}, doc: "Pre and post filtering cell counts tsv" }
-  seurat_prefilter_data: { type: File,  outputBinding: { glob: "*.seurat.counts_and_metrics.RData"}, doc: "Seurat Rdata object with prefilter counts and metrics" }
-  seurat_filtered_data: { type: File,  outputBinding: { glob: "*.seurat.filtered.counts_and_metrics.RData"}, doc: "Seurat Rdata object with basic filter counts and metrics" }
-  variable_features_plot: { type: File, outputBinding: { glob: "*.variable_features.pdf"} , doc: "PDF with a dot plot of variable genes with top 15 labeled"}
+  qc_cell_counts: { type: File, outputBinding: { glob: "*.cell_counts.tsv"}, doc: "Pre and post filtering cell counts tsv" }
+  qc_filtered_ct_matrix: { type: File, outputBinding: { glob: "*qc_filtered.counts_matrix.h5"}, doc: "h5 formatted counts matrix after applying minimum QC filtering" }
+  qc_variable_features_plot: { type: File, outputBinding: { glob: "*.variable_features.pdf"} , doc: "PDF with a dot plot of variable genes with top 20 labeled" }

--- a/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
+++ b/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
@@ -207,15 +207,13 @@ outputs:
   star_solo_junctions: {type: File, outputSource: star_solo_align/junctions_out, doc: "STAR splice junction result file"}
   star_solo_cr_mimic_counts: {type: File, outputSource: tar_solo_cr_mimic_dir/output, doc: "Tar ball of Cell Ranger-style counts dir
       from STAR Solo"}
+  qc_barcode_metrics: { type: File, outputSource: seurat_hbc_qc/qc_barcode_metrics, doc: "Table with barcodes and calculated QC metrics" }
   qc_plots: {type: File, outputSource: seurat_hbc_qc/qc_plots, doc: "Pre and post filtering metrics PDF plots"}
   qc_boxplot_stats: {type: File, outputSource: seurat_hbc_qc/qc_boxplot_stats, doc: "Pre and post filtering boxplot stats TSV"}
-  cell_counts: {type: File, outputSource: seurat_hbc_qc/cell_counts, doc: "Pre and post filtering cell counts TSV"}
-  seurat_prefilter_data: {type: File, outputSource: seurat_hbc_qc/seurat_prefilter_data, doc: "Seurat Rdata object with prefilter
-      counts and metrics"}
-  seurat_filtered_data: {type: File, outputSource: seurat_hbc_qc/seurat_filtered_data, doc: "Seurat Rdata object with basic filter
-      counts and metrics"}
-  variable_features_plot: {type: File, outputSource: seurat_hbc_qc/variable_features_plot, doc: "PDF with a dot plot of variable genes
-      with top 15 labeled"}
+  qc_cell_counts: {type: File, outputSource: seurat_hbc_qc/qc_cell_counts, doc: "Pre and post filtering cell counts TSV"}
+  qc_filtered_ct_matrix: {type: File, outputSource: seurat_hbc_qc/qc_filtered_ct_matrix, doc: "h5 formatted counts matrix after applying minimum QC filtering" }
+  qc_variable_features_plot: {type: File, outputSource: seurat_hbc_qc/qc_variable_features_plot, doc: "PDF with a dot plot of variable genes
+      with top 20 labeled"}
 steps:
   star_solo_align:
     run: ../tools/star_solo_2.7.10b.cwl
@@ -283,7 +281,7 @@ steps:
       min_complexity: qc_min_complexity
       max_mito_ratio: qc_max_mito_ratio
       min_gene_prevalence: qc_min_gene_prevalence
-    out: [qc_plots, qc_boxplot_stats, cell_counts, seurat_prefilter_data, seurat_filtered_data, variable_features_plot]
+    out: [qc_barcode_metrics, qc_plots, qc_boxplot_stats, qc_cell_counts, qc_filtered_ct_matrix, qc_variable_features_plot]
 
 sbg:license: Apache License 2.0
 sbg:publisher: KFDRC

--- a/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
+++ b/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
@@ -81,12 +81,12 @@ doc: |
      - default: "EmptyDrops_CR"
     outSAMtype: type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second is sort type (Unsorted or SortedByCoordinate)
      - default: "None"
-  ### seurat hbc qc
+  ### seurat Harvard Bioinformatics Core (HBC) qc
    - `qc_min_umi`: minimum number of umi for cell-level filtering
    - `qc_min_genes`: minimum number of genes for cell-level filtering
    - `qc_min_complexity`: minimum novelty score (log10GenesPerUMI)
    - `qc_max_mito_ratio`: maximum ratio mitochondrial reads per cell
-   - `qc_min_gene_prevalence`: Minimum number of cells a gene must be expressed in to keep after filtering
+   - `qc_min_gene_prevalence`: minimum number of cells a gene must be expressed in to keep after filtering
 
   ## Outputs
    - `star_solo_counts_dir`: Tar gzipped counts output from STAR Solo
@@ -96,12 +96,12 @@ doc: |
    - `star_solo_log_final_out`: STAR align summary stats
    - `star_solo_junctions`: STAR splice junction result file
    - `star_solo_cr_mimic_counts`: Tar ball of Cell Ranger-style counts dir from STAR Solo
+   - `qc_barcode_metrics`: Table with barcodes and calculated QC metrics
    - `qc_plots`: Pre and post filtering metrics PDF plots
    - `qc_boxplot_stats`: Pre and post filtering boxplot stats TSV
-   - `cell_counts`: Pre and post filtering cell counts TSV
-   - `seurat_prefilter_data`: Seurat Rdata object with prefilter counts and metrics
-   - `seurat_filtered_data`: Seurat Rdata object with basic filter counts and metrics
-   - `variable_features_plot`: PDF with a dot plot of variable genes with top 15 labeled
+   - `qc_cell_counts`: Pre and post filtering cell counts TSV
+   - `qc_filtered_ct_matrix`: h5 formatted counts matrix after applying minimum QC filtering
+   - `qc_variable_features_plot`: PDF with a dot plot of variable genes with top 15 labeled
   ## Appendix: Seurat HBC QC Output
   QC Outputs are based primarily on the training materials provided by the [Harvard Chan Bioinformatics Core](https://github.com/hbctraining/scRNA-seq_online/blob/scRNAseq/lessons/04_SC_quality_control.md).
   An overview of how the QC was performed and overview of the outputs are provided [here](./10X_SEURAT_HBC_SCRNA_QC.md)
@@ -196,6 +196,8 @@ inputs:
   qc_min_complexity: {type: 'float?', doc: "minimum novelty score (log10GenesPerUMI)", default: 0.8}
   qc_max_mito_ratio: {type: 'float?', doc: "maximum ratio mitochondrial reads per cell", default: 0.2}
   qc_min_gene_prevalence: {type: 'int?', doc: "Minimum number of cells a gene must be expressed in to keep after filtering", default: 10}
+  qc_memory: { type: 'int?', doc: "Memory in GB that ought to be available to the script", default: 16 }
+
 outputs:
   star_solo_counts_dir: {type: File, outputSource: tar_solo_count_outdir/output, doc: "Tar gzipped counts output from STAR Solo"}
   star_solo_bam: {type: 'File?', outputSource: star_solo_align/genomic_bam_out, doc: "If flag given, aligned reads file"}
@@ -207,13 +209,14 @@ outputs:
   star_solo_junctions: {type: File, outputSource: star_solo_align/junctions_out, doc: "STAR splice junction result file"}
   star_solo_cr_mimic_counts: {type: File, outputSource: tar_solo_cr_mimic_dir/output, doc: "Tar ball of Cell Ranger-style counts dir
       from STAR Solo"}
-  qc_barcode_metrics: { type: File, outputSource: seurat_hbc_qc/qc_barcode_metrics, doc: "Table with barcodes and calculated QC metrics" }
+  qc_barcode_metrics: {type: File, outputSource: seurat_hbc_qc/qc_barcode_metrics, doc: "Table with barcodes and calculated QC metrics"}
   qc_plots: {type: File, outputSource: seurat_hbc_qc/qc_plots, doc: "Pre and post filtering metrics PDF plots"}
   qc_boxplot_stats: {type: File, outputSource: seurat_hbc_qc/qc_boxplot_stats, doc: "Pre and post filtering boxplot stats TSV"}
   qc_cell_counts: {type: File, outputSource: seurat_hbc_qc/qc_cell_counts, doc: "Pre and post filtering cell counts TSV"}
-  qc_filtered_ct_matrix: {type: File, outputSource: seurat_hbc_qc/qc_filtered_ct_matrix, doc: "h5 formatted counts matrix after applying minimum QC filtering" }
-  qc_variable_features_plot: {type: File, outputSource: seurat_hbc_qc/qc_variable_features_plot, doc: "PDF with a dot plot of variable genes
-      with top 20 labeled"}
+  qc_filtered_ct_matrix: {type: File, outputSource: seurat_hbc_qc/qc_filtered_ct_matrix, doc: "h5 formatted counts matrix after applying
+      minimum QC filtering"}
+  qc_variable_features_plot: {type: File, outputSource: seurat_hbc_qc/qc_variable_features_plot, doc: "PDF with a dot plot of variable
+      genes with top 20 labeled"}
 steps:
   star_solo_align:
     run: ../tools/star_solo_2.7.10b.cwl
@@ -281,6 +284,7 @@ steps:
       min_complexity: qc_min_complexity
       max_mito_ratio: qc_max_mito_ratio
       min_gene_prevalence: qc_min_gene_prevalence
+      memory: qc_memory
     out: [qc_barcode_metrics, qc_plots, qc_boxplot_stats, qc_cell_counts, qc_filtered_ct_matrix, qc_variable_features_plot]
 
 sbg:license: Apache License 2.0


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

RDS files are generally undesirable as they are sensitive to R versions and can be a bit bloated. Critical info has been broken out into TSV and h5 format files:
 - QC metrics no longer buries in seurat object pulling them out into a simple TSV file
 - Typical counts matrix store in h5 format instead, which can easily be converted into Cell Ranger style directories using `DropletUtils` _and_ read in directly using popular Single Cell analysis software suite Seurat using `Read10X_h5`
 - Updated docs to reflect these changes and prep for prod release

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] [QC only](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/0c5e59d2-a247-4d84-9fff-54299427559d)
- [ ] [Within workflow](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/eb12edf5-1c99-4c06-814c-a6e1cce556f3) - note, minor difference that table header names are different, before change implemented


**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
