### PR TITLE
🔧 Fix FASTQ Bug

### DIFF
--- a/docs/10X_STAR_Solo_alignment.md
+++ b/docs/10X_STAR_Solo_alignment.md
@@ -31,7 +31,7 @@ They can also be obtained from the following sources:
  - `r2_max_len`: Set read2 to a fixed length. Useful for single cell experiments in which the number of cycles was improperly configured during sequencing. Recommend `91` for 10X v3 chemistry
 
 ### STAR Solo
- - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example `ID:HFWFVDMXX.L001	LB:750189	PL:ILLUMINA	SM:BS_W72364MN`. If more than one fastq pair in input, it is recommended to have one read group per pair, separated by space-comma-space (` , `)
+ - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example `ID:HFWFVDMXX.L001	LB:750189	PL:ILLUMINA	SM:BS_W72364MN`. If more than one fastq pair in input, it is recommended to have one read group per pair
  - `outSAMattributes`: Set if outputting bam, a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf
  - `genomeDir`: Tar gzipped reference that will be unzipped at run time
  - `readFilesIn1`: Input fastq file(s), gzipped or uncompressed

--- a/docs/10X_STAR_Solo_alignment.md
+++ b/docs/10X_STAR_Solo_alignment.md
@@ -32,6 +32,7 @@ They can also be obtained from the following sources:
 
 ### STAR Solo
  - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example ID:7316-242	LB:750189	PL:ILLUMINA	SM:BS_W72364MN
+ - `outSAMattributes`: Set if outputting bam, a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf
  - `genomeDir`: Tar gzipped reference that will be unzipped at run time
  - `readFilesIn1`: Input fastq file(s), gzipped or uncompressed
  - `readFilesIn2` R2 or 'mates' reads file(s), gzipped or uncompressed

--- a/docs/10X_STAR_Solo_alignment.md
+++ b/docs/10X_STAR_Solo_alignment.md
@@ -31,7 +31,7 @@ They can also be obtained from the following sources:
  - `r2_max_len`: Set read2 to a fixed length. Useful for single cell experiments in which the number of cycles was improperly configured during sequencing. Recommend `91` for 10X v3 chemistry
 
 ### STAR Solo
- - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example ID:7316-242	LB:750189	PL:ILLUMINA	SM:BS_W72364MN
+ - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example `ID:HFWFVDMXX.L001	LB:750189	PL:ILLUMINA	SM:BS_W72364MN`. If more than one fastq pair in input, it is recommended to have one read group per pair, separated by space-comma-space (` , `)
  - `outSAMattributes`: Set if outputting bam, a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf
  - `genomeDir`: Tar gzipped reference that will be unzipped at run time
  - `readFilesIn1`: Input fastq file(s), gzipped or uncompressed
@@ -100,7 +100,7 @@ They can also be obtained from the following sources:
    - CellRanger2.2: simple filtering of CellRanger 2.2. Can be followed by numbers: number of expected cells, robust maximum percentile for UMI count, maximum to minimum ratio for UMI count. The harcoded values are from CellRanger: nExpectedCells=3000; maxPercentile=0.99; maxMinRatio=10
    - EmptyDrops_CR: EmptyDrops filtering in CellRanger flavor. Please cite the original EmptyDrops paper: A.T.L Lun et al, Genome Biology, 20, 63 (2019): https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1662-y, Can be followed by 10 numeric parameters: nExpectedCells maxPercentile maxMinRatio indMin indMax umiMin umiMinFracMedian candMaxN FDR simN. The harcoded values are from CellRanger: 3000 0.99 10 45000 90000 500 0.01 20000 0.01 10000
    - default: "EmptyDrops_CR"
- - `outSAMtype`: type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second is sort type (Unsorted or SortedByCoordinate)
+ - `outSAMtype`: type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second, if BAM, is sort type (Unsorted or SortedByCoordinate)
    - default: "None"
  - `star_extra_args`: Any additional arguments for this tool. See STAR Documentation for complete list of options. Example input: `--limitSjdbInsertNsj 1000001`
 ### seurat Harvard Bioinformatics Core (HBC) qc

--- a/tools/star_solo_2.7.10b.cwl
+++ b/tools/star_solo_2.7.10b.cwl
@@ -24,6 +24,7 @@ arguments:
       --genomeDir ./$(inputs.genomeDir.nameroot.replace(".tar", ""))/
       --readFilesCommand $(inputs.readFilesIn1[0].nameext == '.gz' ? 'zcat' : '-')
       --outFileNamePrefix $(inputs.outFileNamePrefix).
+      $(inputs.outSAMattrRGline ? "--outSAMattrRGline " + inputs.outSAMattrRGline.join(" , ") : "")
 
 inputs:
   genomeDir: { type: File, doc: "Tar gzipped reference that will be unzipped at run time" }
@@ -36,10 +37,9 @@ inputs:
     Tool will add '.' after prefix to easily delineate between file name and suffix" }
   twopassMode: { type: ['null', {type: enum, name: twopassMode, symbols: ["Basic", "None"]}], default: "None",
     doc: "Enable two pass mode to detect novel splice events. Default is None (off).", inputBinding: { position: 5, prefix: '--twopassMode' } }
-  outSAMattrRGline: { type: 'string?', doc: "Set if outputting bam, with TABS SEPARATING \
+  outSAMattrRGline: { type: 'string[]?', doc: "Set if outputting bam, with TABS SEPARATING \
       THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for \
-      example ID:7316-242 LB:750189 PL:ILLUMINA SM:BS_W72364MN",
-      inputBinding: { position: 5, prefix: '--outSAMattrRGline', shellQuote: false } }
+      example ID:7316-242 LB:750189 PL:ILLUMINA SM:BS_W72364MN" }
   outSAMattributes: { type: 'string?', doc: "a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. \
       Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf",
       inputBinding: { position: 5, prefix: '--outSAMattributes', shellQuote: false } }

--- a/tools/star_solo_2.7.10b.cwl
+++ b/tools/star_solo_2.7.10b.cwl
@@ -40,6 +40,9 @@ inputs:
       THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for \
       example ID:7316-242 LB:750189 PL:ILLUMINA SM:BS_W72364MN",
       inputBinding: { position: 5, prefix: '--outSAMattrRGline', shellQuote: false } }
+  outSAMattributes: { type: 'string?', doc: "a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. \
+      Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf",
+      inputBinding: { position: 5, prefix: '--outSAMattributes', shellQuote: false } }
   solo_type: { type: [ 'null', {type: enum, name: soloType, symbols: ["CB_UMI_Simple", "CB UMI Complex", "CB samTagOut", "SmartSeq"]}],
     doc: "type of single-cell RNAseq. \
     CB_UMI_Simple: (a.k.a. Droplet) one UMI and one Cell Barcode of fixed length in read2, e.g. Drop-seq and 10X Chromium, \

--- a/tools/star_solo_2.7.10b.cwl
+++ b/tools/star_solo_2.7.10b.cwl
@@ -110,15 +110,15 @@ inputs:
     Rescue: distributes multi-gene UMIs to their gene set proportionally to the sum of the number of unique-gene UMIs and uniformly distributed multi-gene UMIs in each gene Mortazavi et al. It can be thought of as the first step of the EM algorithm",
     inputBinding: { position: 5, prefix: "--soloMultiMappers" } }
   extra_args: { type: 'string?', inputBinding: { position: 5, shellQuote: false }, doc: "Any additional arguments for this tool. See STAR Documentation for complete list of options. Example input: --limitSjdbInsertNsj 1000001" }
-  outSAMtype: { type: [ 'null', {type: enum, name: outSAMtype, symbols: ["BAM Unsorted", "None", "BAM SortedByCoordinate", "SAM Unsorted", "SAM SortedByCoordinate"]}],
+  outSAMtype: { type: [ 'null', {type: enum, name: outSAMtype, symbols: ["BAM Unsorted", "None", "BAM SortedByCoordinate", "SAM"]}],
     default: "None",
-    doc: "type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second is sort type (Unsorted or SortedByCoordinate)",
+    doc: "type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second, if BAM, is sort type (Unsorted or SortedByCoordinate)",
     inputBinding: { position: 3, prefix: '--outSAMtype', shellQuote: false } }
 
 outputs:
   log_progress_out: { type: File, doc: "Simple progress output. Can use to gauge speed and run time", outputBinding: {glob: '*Log.progress.out'} }
   log_out: { type: File, doc: "Contains a summary of all params used and reference files", outputBinding: {glob: '*Log.out'} }
   log_final_out: { type: File, doc: "Overall summary of read mapping statistics", outputBinding: {glob: '*Log.final.out'} }
-  genomic_bam_out: { type: 'File?', doc: "UNSORTED read mapping to genomic coordinates", outputBinding: {glob: '*Aligned*bam'} }
+  genomic_bam_out: { type: 'File?', doc: "Reads mapping to genomic coordinates", outputBinding: {glob: '*Aligned*[b|s]am'} }
   junctions_out: { type: File, doc: "high confidence collapsed splice junctions in tab-delimited form", outputBinding: {glob: '*SJ.out.tab'} }
   counts_dir: { type: Directory, doc: "Output dir with raw and filtered counts", outputBinding: { glob: '*.Solo.out'} }

--- a/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
+++ b/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
@@ -37,6 +37,7 @@ doc: |
 
   ### STAR Solo
    - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example ID:7316-242	LB:750189	PL:ILLUMINA	SM:BS_W72364MN
+   - `outSAMattributes`: Set if outputting bam, a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf
    - `genomeDir`: Tar gzipped reference that will be unzipped at run time
    - `readFilesIn1`: Input fastq file(s), gzipped or uncompressed
    - `readFilesIn2` R2 or 'mates' reads file(s), gzipped or uncompressed
@@ -152,6 +153,8 @@ inputs:
   runThreadN: {type: 'int?', doc: "Num threads for STAR Solo to use", default: 16}
   outSAMattrRGline: {type: 'string?', doc: "Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id
       PL:platform SM:BSID for example ID:7316-242 LB:750189 PL:ILLUMINA SM:BS_W72364MN"}
+  outSAMattributes: {type: 'string?', doc: "a string of desired SAM attributes, in the order desired for the output SAM. Tags can
+      be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf"}
   twopassMode: {type: ['null', {type: enum, name: twopassMode, symbols: ["Basic", "None"]}], default: "Basic", doc: "Enable two pass
       mode to detect novel splice events. Default is Basic (on)."}
   solo_type: {type: ['null', {type: enum, name: soloType, symbols: ["CB_UMI_Simple", "CB UMI Complex", "CB samTagOut", "SmartSeq"]}],
@@ -273,14 +276,15 @@ steps:
     run: ../tools/star_solo_2.7.10b.cwl
     in:
       outSAMattrRGline: outSAMattrRGline
+      outSAMattributes: outSAMattributes
       twopassMode: twopassMode
       genomeDir: genomeDir
       readFilesIn1:
         source: [cutadapt_fixed_length/trimmedReadsR1, readFilesIn1]
-        pickValue: first_non_null
+        valueFrom: "$(self[0].every(function(e) { return e != null }) ? self[0] : self[1])"
       readFilesIn2:
         source: [cutadapt_fixed_length/trimmedReadsR2, readFilesIn2]
-        pickValue: first_non_null
+        valueFrom: "$(self[0].every(function(e) { return e != null }) ? self[0] : self[1])"
       runThreadN: runThreadN
       outFileNamePrefix: output_basename
       solo_type: solo_type

--- a/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
+++ b/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
@@ -36,7 +36,7 @@ doc: |
    - `r2_max_len`: Set read2 to a fixed length. Useful for single cell experiments in which the number of cycles was improperly configured during sequencing. Recommend `91` for 10X v3 chemistry
 
   ### STAR Solo
-   - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example `ID:HFWFVDMXX.L001	LB:750189	PL:ILLUMINA	SM:BS_W72364MN`. If more than one fastq pair in input, it is recommended to have one read group per pair, separated by space-comma-space (` , `)
+   - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example `ID:HFWFVDMXX.L001	LB:750189	PL:ILLUMINA	SM:BS_W72364MN`. If more than one fastq pair in input, it is recommended to have one read group per pair
    - `outSAMattributes`: Set if outputting bam, a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf
    - `genomeDir`: Tar gzipped reference that will be unzipped at run time
    - `readFilesIn1`: Input fastq file(s), gzipped or uncompressed
@@ -151,7 +151,7 @@ inputs:
   readFilesIn1: {type: 'File[]', doc: "Input fastq file(s), gzipped or uncompressed"}
   readFilesIn2: {type: 'File[]', doc: "R2 or 'mates' reads file(s), gzipped or uncompressed"}
   runThreadN: {type: 'int?', doc: "Num threads for STAR Solo to use", default: 16}
-  outSAMattrRGline: {type: 'string?', doc: "Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id
+  outSAMattrRGline: {type: 'string[]?', doc: "Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id
       PL:platform SM:BSID for example ID:7316-242 LB:750189 PL:ILLUMINA SM:BS_W72364MN"}
   outSAMattributes: {type: 'string?', doc: "a string of desired SAM attributes, in the order desired for the output SAM. Tags can
       be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf"}

--- a/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
+++ b/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
@@ -36,7 +36,7 @@ doc: |
    - `r2_max_len`: Set read2 to a fixed length. Useful for single cell experiments in which the number of cycles was improperly configured during sequencing. Recommend `91` for 10X v3 chemistry
 
   ### STAR Solo
-   - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example ID:7316-242	LB:750189	PL:ILLUMINA	SM:BS_W72364MN
+   - `outSAMattrRGline`: Set if outputting bam, with TABS SEPARATING THE TAGS, format is: ID:sample_name LB:aliquot_id PL:platform SM:BSID for example `ID:HFWFVDMXX.L001	LB:750189	PL:ILLUMINA	SM:BS_W72364MN`. If more than one fastq pair in input, it is recommended to have one read group per pair, separated by space-comma-space (` , `)
    - `outSAMattributes`: Set if outputting bam, a string of desired SAM attributes, in the order desired for the output SAM. Tags can be listed in any combination/order. Please refer to the STAR manual, as there are numerous combinations: https://raw.githubusercontent.com/alexdobin/STAR/master/doc/STARmanual.pdf
    - `genomeDir`: Tar gzipped reference that will be unzipped at run time
    - `readFilesIn1`: Input fastq file(s), gzipped or uncompressed
@@ -105,7 +105,7 @@ doc: |
      - CellRanger2.2: simple filtering of CellRanger 2.2. Can be followed by numbers: number of expected cells, robust maximum percentile for UMI count, maximum to minimum ratio for UMI count. The harcoded values are from CellRanger: nExpectedCells=3000; maxPercentile=0.99; maxMinRatio=10
      - EmptyDrops_CR: EmptyDrops filtering in CellRanger flavor. Please cite the original EmptyDrops paper: A.T.L Lun et al, Genome Biology, 20, 63 (2019): https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1662-y, Can be followed by 10 numeric parameters: nExpectedCells maxPercentile maxMinRatio indMin indMax umiMin umiMinFracMedian candMaxN FDR simN. The harcoded values are from CellRanger: 3000 0.99 10 45000 90000 500 0.01 20000 0.01 10000
      - default: "EmptyDrops_CR"
-   - `outSAMtype`: type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second is sort type (Unsorted or SortedByCoordinate)
+   - `outSAMtype`: type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second, if BAM, is sort type (Unsorted or SortedByCoordinate)
      - default: "None"
    - `star_extra_args`: Any additional arguments for this tool. See STAR Documentation for complete list of options. Example input: `--limitSjdbInsertNsj 1000001`
   ### seurat Harvard Bioinformatics Core (HBC) qc
@@ -224,9 +224,9 @@ inputs:
   raw_count_choice: {type: ['null', {type: enum, name: raw_count_choice, symbols: ["Unique", "Uniform", "PropUnique", "EM", "Rescue"]}],
     doc: "Based on `soloMultiMappers`, if you wish to include/handle multi-gene hits in downstream anaylsis instead of default (ignore
       multi-gene mappers), pick the method you want to use", default: "EM"}
-  outSAMtype: {type: ['null', {type: enum, name: outSAMtype, symbols: ["BAM Unsorted", "None", "BAM SortedByCoordinate", "SAM Unsorted",
-          "SAM SortedByCoordinate"]}], default: "None", doc: "type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word
-      is output type (BAM or SAM), second is sort type (Unsorted or SortedByCoordinate)"}
+  outSAMtype: {type: ['null', {type: enum, name: outSAMtype, symbols: ["BAM Unsorted", "None", "BAM SortedByCoordinate", "SAM"]}],
+    default: "None", doc: "type of SAM/BAM output. None: no SAM/BAM output. Otherwise, first word is output type (BAM or SAM), second,
+      if BAM, is sort type (Unsorted or SortedByCoordinate)"}
   star_extra_args: {type: 'string?', doc: "Any additional arguments for this tool. See STAR Documentation for complete list of options.
       Example input: --limitSjdbInsertNsj 1000001"}
   # Seurat HBC QC

--- a/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
+++ b/workflows/kf_STAR_Solo_10x_alignment_wf.cwl
@@ -353,7 +353,7 @@ $namespaces:
 "sbg:license": Apache License 2.0
 "sbg:publisher": KFDRC
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-dev-single-cell-rna/releases/tag/v1.1.1'
+- id: 'https://github.com/kids-first/kf-dev-single-cell-rna/releases/tag/v1.1.2'
   label: github-release
 hints:
 - class: 'sbg:maxNumberOfParallelInstances'


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

A recent update to add a scatter job of cutadapt to fix lengths of inputs introduced a bug in which if a user does not provide lengths to fix, the workflow does not pass the correct input to STAR causing failure. This replaces pickValue with a valueFrom to better asses a [null, null] evaluation. Als,o more for added functionality, is the read group name input in the rare event a user wants to keep the bam output

Fixes # https://d3b.atlassian.net/browse/BIXU-3795

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] [Test with lengths set](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/f042f1e9-f473-4f41-b323-6a0506eb7a22/)
- [ ] [Test with no lengths set, bug fix](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/951e372f-61f0-4326-9382-79f19d32b662/)
- [ ] [Test added functionality SAM out and multi-rg](https://cavatica.sbgenomics.com/u/d3b-bixu/kf-dev-single-cell-rna/tasks/e1ff0442-d1fb-42f3-9671-4ce795830e21/)

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
