### PR TITLE
🔧  alt meta manipulation

### DIFF
--- a/nf/SWANS/modules/local/convert_h5/main.nf
+++ b/nf/SWANS/modules/local/convert_h5/main.nf
@@ -6,7 +6,7 @@ process CONVERT_H5 {
     tuple val(meta), path(h5_raw), path(h5_filtered)
 
     output:
-    tuple val(updated_meta), path(sample_id)
+    tuple val(meta), path(sample_id)
 
     script:
     sample_id = meta.sample_id

--- a/nf/SWANS/modules/local/untar/main.nf
+++ b/nf/SWANS/modules/local/untar/main.nf
@@ -6,7 +6,7 @@ process UNTAR_CR {
     tuple val(meta), path(tar_file)
 
     output:
-    tuple val(updated_meta), stdout, path("*")
+    tuple val(meta), path("*")
 
     script:
     cr_tar_args = "--ignore-failed-read " +
@@ -18,10 +18,8 @@ process UNTAR_CR {
     "--show-transformed-names"
     tar_args = meta.input_type.contains("cellranger") ? cr_tar_args : ""
     // replace output type with dir prefix in metadata
-    updated_meta = meta + ["input_type": meta.input_type.replace("tar_", "dir_")]
     """
     tar xvf $tar_file \\
-    $tar_args \\
-    | cut -f 1 -d "/" | uniq
+    $tar_args
     """
 }

--- a/nf/SWANS/subworkflows/local/format_inputs/main.nf
+++ b/nf/SWANS/subworkflows/local/format_inputs/main.nf
@@ -23,7 +23,7 @@ workflow format_inputs {
     // else process as normal, but update associated path with dir path from untar
     UNTAR_CR.out.branch { meta, dir_path ->
         multi: meta.input_type.equals("dir_cellranger_multi")
-            return dir_path.map{ dir -> [["name": meta.name, "sample_id": dir.baseName], dir] }
+            return dir_path.collect{ dir -> [["name": meta.name, "sample_id": dir.baseName], dir] }
         count: meta.input_type.equals("dir_cellranger_count")
             return [meta, dir_path]
         doublet: meta.input_type.equalsIgnoreCase("dir_doubletFinder")

--- a/nf/SWANS/test_inputs/cr_h5_multi.json
+++ b/nf/SWANS/test_inputs/cr_h5_multi.json
@@ -1,0 +1,11 @@
+{
+    "project": "HOPE_h5_multi_TEST",
+    "input_sample_sheet": "/home/ubuntu/volume/SWANS/NF_TEST/hope_h5_muilt_test.tsv",
+    "dbl_mem": 30,
+    "disable_doubletfinder": false,
+    "disable_soupx": false,
+    "dbl_threads": 2,
+    "soupx_start": "no_clusters",
+    "organism": "human",
+    "aws_test_instance": true
+}


### PR DESCRIPTION
Two things:
- Changed the untar to drop the `| cut | uniq` pipe and moved that out to a `baseName` call. I'm not sure if this replicates the functionality you were going for but it seems safer.
- Alternative approach to meta manipulation. Moving it out of the modules and into the subworkflow main. Mostly just to keep the meta manipulation all in the workflow and keep the modules commandline focused.